### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/stag-build.yaml
+++ b/.github/workflows/stag-build.yaml
@@ -43,7 +43,7 @@ jobs:
           region: ${{ secrets.AWS_REGION }}
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{env.SERVICE_NAME}}-${{env.SERVICE_TYPE}}
           username: ${{ steps.ecr.outputs.username }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore